### PR TITLE
Page.update() is deprecated

### DIFF
--- a/template/src/pages/index/index.js
+++ b/template/src/pages/index/index.js
@@ -25,6 +25,5 @@ export default class Index extends wx.Component {
     this.setData({
       userInfo: userInfo
     });
-    this.update();
   }
 }


### PR DESCRIPTION
真机报 Page.update() is deprecated warning，其实用 .setData() 让视图更新就可以了。
