### PR TITLE
添加对SASS的支持，build、watch命令支持.sass或.scss编译为.wxss

### DIFF
--- a/lib/build-sass.js
+++ b/lib/build-sass.js
@@ -1,0 +1,85 @@
+/**
+ * @copyright Maichong Software Ltd. 2016 http://maichong.it
+ * @date 2016-09-25
+ * @author soulwu <soulwuzjjx@vip.qq.com>
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const sass = require('node-sass');
+const promisify = require('es6-promisify');
+const render = promisify(sass.render);
+const utils = require('./utils');
+const config = require('./config')();
+require('colors');
+
+/**
+ * @param {FileInfo} from
+ * @param {Object} depends
+ * @returns {string}
+ */
+function build(from, depends) {
+  if (typeof from === 'string') {
+    from = utils.getInfo(from);
+  }
+  const componentsPath = config.srcDir + 'components/';
+
+  let data = fs.readFileSync(from.file, 'utf8');
+  return data.replace(/@import\s+['"]([\w\d\.\-_\/]+)['"];?/ig, (match, lib) => {
+    //尝试加载 相对目录或同一目录下指定的scss文件
+    let src = path.join(from.dir, lib);
+    if (!utils.isFile(src)) {
+      //尝试加载 没有指定scss后缀时,相对目录或同一目录下指定的scss文件
+      src = path.join(from.dir, lib + '.scss');
+      if (!utils.isFile(src)) {
+        //尝试加载 尝试.sass后缀
+        src = path.join(from.dir, lib + '.sass');
+        if (!utils.isFile(src)) {
+          //尝试加载 components 目录下的通用组件样式
+          src = path.join(componentsPath, lib, lib + '.scss');
+          if (!utils.isFile(src)) {
+            //尝试加载 components 目录下的.sass后缀
+            src = path.join(componentsPath, lib, lib + '.sass');
+            if (!utils.isFile(src)) {
+              //尝试加载 node_modules 目录下的index.scss
+              src = path.join(config.modulesDir, lib, 'index.scss');
+              if (!utils.isFile(src)) {
+                //尝试加载 node_modules 目录下的index.sass
+                src = path.join(config.modulesDir, lib, 'index.sass');
+                if (!utils.isFile(src)) {
+                  //尝试加载 node_modules 目录下的指定scss文件
+                  src = path.join(config.modulesDir, lib);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (!utils.isFile(src)) {
+      throw new Error(`Can not import scss file '${lib}' from ` + from.relative);
+    }
+    depends[src] = true;
+    return build(src, depends);
+  });
+}
+
+/**
+ * 编译LESS
+ * @param {FileInfo} from
+ * @param {FileInfo} to
+ * @returns {Array}
+ */
+module.exports = function* buildSass(from, to) {
+  console.log('build sass'.green, from.relative.blue, '->', to.relative.cyan);
+  let depends = {};
+  let data = build(from, depends);
+  let result = yield render({ data, outputStyle: 'expanded', includePaths: [from.dir] });
+  if (!result.css) return [];
+  mkdirp.sync(to.dir);
+  fs.writeFileSync(to.file, result.css);
+  return Object.keys(depends);
+};

--- a/lib/build.js
+++ b/lib/build.js
@@ -12,6 +12,7 @@ const mkdirp = require('mkdirp');
 const utils = require('./utils');
 const buildJS = require('./build-js');
 const buildLess = require('./build-less');
+const buildSass = require('./build-sass');
 const buildXML = require('./build-xml');
 const minifyPage = require('./minify-page');
 const minifyJs = require('./minify-js');
@@ -58,6 +59,15 @@ function* build(options) {
         if (from.fromSrc === 'app.less' || utils.inPages(from.file)) {
           targets[to.file] = true;
           yield* buildLess(from, to);
+        } else {
+          console.log('ignore'.yellow, from.relative.gray);
+        }
+        break;
+      case '.sass':
+      case '.scss':
+        if (from.fromSrc === 'app.sass' || from.fromSrc === 'app.scss' || utils.inPages(from.file)) {
+          targets[to.file] = true;
+          yield* buildSass(from, to);
         } else {
           console.log('ignore'.yellow, from.relative.gray);
         }

--- a/lib/generate-component.js
+++ b/lib/generate-component.js
@@ -25,7 +25,7 @@ function generateComponent(name, options) {
 
   mkdirp.sync(path.dirname(fileBase));
 
-  ['.js', '.xml', '.less', '.test.js'].forEach((ext) => {
+  ['.js', '.xml', (options.scss ? '.scss' : '.less'), '.test.js'].forEach((ext) => {
     let target = fileBase + ext;
     if (utils.isFile(target)) {
       console.error(`组件创建失败："${path.relative(config.workDir, target)}" 已经存在`.red);

--- a/lib/generate-page.js
+++ b/lib/generate-page.js
@@ -26,7 +26,7 @@ function generatePage(name, options) {
 
   mkdirp.sync(path.dirname(fileBase));
 
-  ['.js', '.xml', '.less', '.test.js'].forEach((ext) => {
+  ['.js', '.xml', (options.scss ? '.scss' : '.less'), '.test.js'].forEach((ext) => {
     let target = fileBase + ext;
     if (utils.isFile(target)) {
       console.error(`组件创建失败："${path.relative(config.workDir, target)}" 已经存在`.red);

--- a/lib/labrador.js
+++ b/lib/labrador.js
@@ -41,6 +41,7 @@ program
   .option('--work-dir [dir]', '工作目录，默认为当前目录')
   .option('--config [file]', '配置文件，默认为.labrador')
   .option('--src-dir [dir]', '源码目录，默认为工作目录下的src文件夹')
+  .option('--scss', '使用scss，默认为less')
   .action((type, name, options) => {
     switch (type) {
       case 'page':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -149,6 +149,7 @@ exports.getDistFileExt = function getDistFileExt(ext) {
   switch (ext) {
     case '.less':
     case '.sass':
+    case '.scss':
       return '.wxss';
     case '.xml':
       return '.wxml';

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -14,6 +14,7 @@ const updateNotifier = require('update-notifier');
 const utils = require('./utils');
 const buildJS = require('./build-js');
 const buildLess = require('./build-less');
+const buildSass = require('./build-sass');
 const buildXML = require('./build-xml');
 require('shelljs/global');
 
@@ -58,6 +59,27 @@ function* watch(options) {
       case '.less':
         if ((from.fromSrc === 'app.less') || utils.inPages(from.file)) {
           let depends = yield* buildLess(from, to);
+          depends.forEach((d) => {
+            d = path.normalize(d);
+            if (!refs[d]) {
+              refs[d] = {};
+            }
+            refs[d][from.file] = true;
+          });
+        } else if (refs[from.file]) {
+          console.log('changed'.green, from.relative.blue);
+          let files = Object.keys(refs[from.file]);
+          for (let s of files) {
+            yield* buildFile(s);
+          }
+        } else {
+          console.log('ignore'.yellow, from.relative.gray);
+        }
+        break;
+      case '.sass':
+      case '.scss':
+        if ((from.fromSrc === 'app.sass') || (from.fromSrc === 'app.scss') || utils.inPages(from.file)) {
+          let depends = yield* buildSass(from, to);
           depends.forEach((d) => {
             d = path.normalize(d);
             if (!refs[d]) {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,22 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "download-github-repo": "^0.1.3",
+    "es6-promisify": "^5.0.0",
     "less": "^2.7.1",
     "mkdirp": "^0.5.1",
+    "node-sass": "^3.13.0",
     "radix64": "^1.1.0",
     "shelljs": "^0.7.4",
     "uglify-js": "^2.7.3",
     "update-notifier": "^1.0.2",
     "xmldom": "^0.1.22"
+  },
+  "devDependencies": {
+    "babel-eslint": "^7.1.1",
+    "eslint": "^3.10.2",
+    "eslint-config-airbnb": "^13.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.7.1"
   }
 }

--- a/templates/component/component.scss
+++ b/templates/component/component.scss
@@ -1,0 +1,6 @@
+@import 'al-ui';
+
+.CLASS_NAME {
+  background: $color-page;
+  font-size: $font-size-medium;
+}


### PR DESCRIPTION
generate命令生成page和component时，支持--scss参数生成.scss文件，而不是.less文件

TODO：如果使用.scss，应该还需要修改对应的demo模板，让create命令也支持--scss选项