### PR TITLE
修复list问题和引入 babel-plugin-transform-decorators-legacy 时报错的问题

### DIFF
--- a/lib/build-js.js
+++ b/lib/build-js.js
@@ -113,7 +113,8 @@ module.exports = function* buildJS(from, to, targets, metadata) {
 
   if (isPage) {
     let defaultExport = 'exports.default';
-    let matchs = code.match(/exports\.default\s*=\s*(\w+);/i);
+    let lastExport = code.match(/exports\.default\s*=\s*(\w+);/ig);
+    let matchs = lastExport && lastExport.pop().match(/exports\.default\s*=\s*(\w+);/i);
     if (matchs) {
       defaultExport = matchs[1];
       code = code.replace(/exports\.default\s*=\s*(\w+);/i, '');

--- a/lib/build-xml.js
+++ b/lib/build-xml.js
@@ -337,7 +337,7 @@ function build(from, comPrefix, valPrefix, clsPrefix, depends) {
     let indexName = '_k' + id;
     let itemName = '_v' + id;
     let subComPrefix = comPrefix ? comPrefix + '.' + key : key;
-    subComPrefix += '.{{' + indexName + '}}';
+    subComPrefix += '.{{' + itemName + '.__k}}';
     let subValPrefix = valPrefix ? valPrefix + '.' + key : key;
     let subClsPrefix = clsPrefix ? clsPrefix + '-' + key : key;
     let listNode = doc.createElement('block');
@@ -405,3 +405,4 @@ module.exports = function* buildXML(from, to) {
   fs.writeFileSync(to.file, xml);
   return Object.keys(depends);
 };
+


### PR DESCRIPTION
<ul>
<li>list在删除了中间item后，从删除位置起后面所有的item在list中的index不会更新，导致删除时找不到对应的item问题</li>
<li>当引入 babel-plugin-transform-decorators-legacy 时, _createPage 参数为 undefined #11</li>
</ul>
