### PR TITLE
fix: 修复无法require带有命名空间的npm包, 如require('@author/package')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 yarn.lock
+
+# idea
+.idea

--- a/lib/build-js.js
+++ b/lib/build-js.js
@@ -136,7 +136,7 @@ module.exports = function* buildJS(from, to, targets, metadata) {
 
   let promises = [];
 
-  code = code.replace(/require\(['"]([\w\d_\-\.\/]+)['"]\)/ig, function (match, lib) {
+  code = code.replace(/require\(['"]([\w\d_\-\.\/\@]+)['"]\)/ig, function (match, lib) {
     //如果引用文件是相对位置引用，并且当前文件不是NPM包文件，不存在映射
     if (lib[0] === '.' && !isNPM) {
       let file = path.join(path.dirname(from.file), lib);
@@ -154,9 +154,10 @@ module.exports = function* buildJS(from, to, targets, metadata) {
     //如果引用NPM包文件
     let source;
     let target;
-    if (lib.indexOf('/') === -1 || lib.indexOf('/') === lib.length - 1) {
+    let isPrivatePackReg = /^\@[\w\d\-\_\.]+\/[\w\d\-\_\.]+$/;
+    if (lib.indexOf('/') === -1 || lib.indexOf('/') === lib.length - 1 || isPrivatePackReg.test(lib)) {
       //只指定了包名
-      lib = lib.replace(/\//, '');
+      if (!isPrivatePackReg.test(lib)) lib = lib.replace(/\//, '');
       if (config.npmMap && config.npmMap.hasOwnProperty(lib)) {
         lib = config.npmMap[lib];
       }
@@ -186,7 +187,7 @@ module.exports = function* buildJS(from, to, targets, metadata) {
       target = path.join(distNpmDir, path.relative(config.modulesDir, source));
     } else {
       //如果还指定了包里边的路径
-      lib = lib.replace(/^([\w\.\-\_]+)/i, function (name) {
+      lib = lib.replace(/^([\w\.\-\_\@]+)/i, function (name) {
         if (config.npmMap && config.npmMap.hasOwnProperty(name)) {
           return config.npmMap[name];
         }

--- a/lib/minify-js.js
+++ b/lib/minify-js.js
@@ -29,7 +29,7 @@ module.exports = function* minifyJs() {
   function compile(file) {
     let code = fs.readFileSync(file, 'utf8');
 
-    code = code.replace(/([\s;]?)require\(['"]([\w\_\-\.\/]+)['"]\)/g, function (matchs, char, ref) {
+    code = code.replace(/([\s;]?)require\(['"]([\w\_\-\.\/\@]+)['"]\)/g, function (matchs, char, ref) {
       let refFile = path.normalize(path.join(path.dirname(file), ref));
       if (fileMap[refFile] === undefined) {
         fileMap[refFile] = compile(refFile);


### PR DESCRIPTION
例如:
```javascript
import WxSocket from '@axetroy/wxapp-socket';

console.dir(WxSocket);
```

## 之前

打包过程不报错，运行时报错
```bash
WAService.js:6 Uncaught Error: module "@axetroy/wxapp-socket.js" is not defined
    at require (WAService.js:6)
    at WAService.js:6
    at app.js:36
    at require (WAService.js:6)
    at app.js [sm]:60
```

## 之后

稍作修改之后可以兼容带有命名空间的包