### PR TITLE
增加build --watch，wxml/wxss/json压缩

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -21,6 +21,7 @@ const minifyPage = require('./minify-page');
 const minifyJs = require('./minify-js');
 const minifyWxml = require('./minify-wxml');
 const minifyWxss = require('./minify-wxss');
+const minifyJson = require('./minify-json');
 require('shelljs/global');
 require('colors');
 
@@ -131,6 +132,9 @@ function* build(options) {
     }
     if(!options.ignoreMinifyWxss){
       yield minifyWxss();
+    }
+    if(!options.ignoreMinifyJson){
+      yield minifyJson();
     }
   }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -19,6 +19,7 @@ const buildSass = require('./build-sass');
 const buildXML = require('./build-xml');
 const minifyPage = require('./minify-page');
 const minifyJs = require('./minify-js');
+const minifyWxml = require('./minify-wxml');
 require('shelljs/global');
 require('colors');
 
@@ -123,6 +124,9 @@ function* build(options) {
     }
     if (!options.ignoreMinifyPage) {
       yield* minifyPage();
+    }
+    if(!options.ignoreMinifyWxml){
+      yield minifyWxml();
     }
   }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -5,7 +5,8 @@
  */
 
 'use strict';
-
+const chokidar = require('chokidar');
+const _ = require('underscore');
 const co = require('co');
 const path = require('path');
 const fs = require('fs');
@@ -20,6 +21,24 @@ const minifyPage = require('./minify-page');
 const minifyJs = require('./minify-js');
 require('shelljs/global');
 require('colors');
+
+const watchFileChangeOnce = _.once(function (config, callback) {
+  chokidar.watch(config.srcDir, {ignored: /^\./}).on('all', (event, source) => {
+    callback.call(this, event, source);
+  });
+});
+
+const startBuild = _.debounce(function (options) {
+  co(build(options)).then(() => {
+    console.log('项目构建完成'.green);
+  }, (error) => {
+    console.log('项目构建失败!'.red);
+    console.log(error.message);
+    if (error.stack) {
+      console.log(error.stack);
+    }
+  });
+}, 300);
 
 function* build(options) {
   const config = require('./config')(options);
@@ -127,17 +146,14 @@ function* build(options) {
       notifier.check();
     }
   });
+
+  // only watch once
+  if (options.watch) {
+    watchFileChangeOnce(config, (event, source) => {
+      startBuild(options)
+    });
+  }
+
 }
 
-
-module.exports = function (options) {
-  co(build(options)).then(() => {
-    console.log('项目构建完成'.green);
-  }, (error) => {
-    console.log('项目构建失败!'.red);
-    console.log(error.message);
-    if (error.stack) {
-      console.log(error.stack);
-    }
-  });
-};
+module.exports = startBuild;

--- a/lib/build.js
+++ b/lib/build.js
@@ -127,13 +127,13 @@ function* build(options) {
     if (!options.ignoreMinifyPage) {
       yield* minifyPage();
     }
-    if(!options.ignoreMinifyWxml){
+    if (!options.ignoreMinifyWxml) {
       yield minifyWxml();
     }
-    if(!options.ignoreMinifyWxss){
+    if (!options.ignoreMinifyWxss) {
       yield minifyWxss();
     }
-    if(!options.ignoreMinifyJson){
+    if (!options.ignoreMinifyJson) {
       yield minifyJson();
     }
   }

--- a/lib/build.js
+++ b/lib/build.js
@@ -20,6 +20,7 @@ const buildXML = require('./build-xml');
 const minifyPage = require('./minify-page');
 const minifyJs = require('./minify-js');
 const minifyWxml = require('./minify-wxml');
+const minifyWxss = require('./minify-wxss');
 require('shelljs/global');
 require('colors');
 
@@ -127,6 +128,9 @@ function* build(options) {
     }
     if(!options.ignoreMinifyWxml){
       yield minifyWxml();
+    }
+    if(!options.ignoreMinifyWxss){
+      yield minifyWxss();
     }
   }
 

--- a/lib/labrador.js
+++ b/lib/labrador.js
@@ -78,6 +78,7 @@ program
   .option('--temp-dir [dir]', '临时目录，默认为工作目录下的.build文件夹')
   .option('--ignore-minify-js', 'minify模式下，不压缩JS代码')
   .option('--ignore-minify-page', 'minify模式下，不强力压缩WXSS和WXML代码')
+  .option('--ignore-minify-wxml', '忽略压缩WXML代码')
   .action((options) => {
     if (!options.minify) {
       if (options.ignoreMinifyJs) {

--- a/lib/labrador.js
+++ b/lib/labrador.js
@@ -79,6 +79,7 @@ program
   .option('--ignore-minify-js', 'minify模式下，不压缩JS代码')
   .option('--ignore-minify-page', 'minify模式下，不强力压缩WXSS和WXML代码')
   .option('--ignore-minify-wxml', '忽略压缩WXML代码')
+  .option('--ignore-minify-wxss', '忽略压缩WXSS代码')
   .action((options) => {
     if (!options.minify) {
       if (options.ignoreMinifyJs) {

--- a/lib/labrador.js
+++ b/lib/labrador.js
@@ -69,6 +69,7 @@ program
   .option('-t, --test', '运行测试脚本')
   .option('-m, --minify', '压缩代码')
   .option('-f, --force', '强制构建，不使用缓存')
+  .option('-w, --watch', '检测文件改动并重新build')
   .option('--work-dir [dir]', '工作目录，默认为当前目录')
   .option('--config [file]', '配置文件，默认为.labrador')
   .option('--src-dir [dir]', '源码目录，默认为工作目录下的src文件夹')

--- a/lib/labrador.js
+++ b/lib/labrador.js
@@ -80,6 +80,7 @@ program
   .option('--ignore-minify-page', 'minify模式下，不强力压缩WXSS和WXML代码')
   .option('--ignore-minify-wxml', '忽略压缩WXML代码')
   .option('--ignore-minify-wxss', '忽略压缩WXSS代码')
+  .option('--ignore-minify-json', '忽略压缩JSON文件')
   .action((options) => {
     if (!options.minify) {
       if (options.ignoreMinifyJs) {

--- a/lib/minify-json.js
+++ b/lib/minify-json.js
@@ -1,0 +1,43 @@
+/**
+ * Created by axetroy on 17-2-13.
+ */
+const path = require('path');
+const fs = require('fs');
+
+const pd = require('pretty-data').pd;
+const config = require('./config')();
+const globby = require('globby');
+const co = require('co');
+
+function *minifyWXML() {
+  const pageFiles = path.join(config.distDir, 'pages/', '**', '**', '*.json');
+  const distAllFiles = path.join(config.distDir, '**', '**', '*.json');
+
+  let files = yield globby([
+    pageFiles,
+    distAllFiles
+  ]);
+
+  return new Promise(function (resolve, reject) {
+    if (!files || !files.length) files = [];
+    files.forEach(function (file) {
+      let fileRaw = fs.readFileSync(file, {encoding: 'utf8'});
+      let minifyData = pd.cssmin(fileRaw);
+      fs.writeFileSync(file, minifyData);
+      console.log('minify'.green, path.relative(config.workDir, file).blue);
+    });
+    resolve(files);
+  });
+}
+
+module.exports = function *() {
+  console.log('minify json...'.green);
+  return co(minifyWXML)
+    .then(function (files) {
+      return Promise.resolve(files);
+    })
+    .catch(function (err) {
+      console.log(err);
+      return Promise.reject(err);
+    })
+};

--- a/lib/minify-wxml.js
+++ b/lib/minify-wxml.js
@@ -1,0 +1,42 @@
+/**
+ * Created by axetroy on 17-2-13.
+ */
+const path = require('path');
+const fs = require('fs');
+
+const pd = require('pretty-data').pd;
+const config = require('./config')();
+const glob = require('glob');
+const co = require('co');
+const utils = require('./utils');
+
+function *minifyWXML() {
+  const srcFiles = path.join(config.distDir, 'pages/', '**', '**', '*.wxml');
+
+  return new Promise(function (resolve, reject) {
+    // options is optional
+    glob(srcFiles, {}, function (err, files) {
+      if (err) return reject(err);
+      if (!files || !files.length) return resolve(null);
+      files.forEach(function (file) {
+        let fileRaw = fs.readFileSync(file, {encoding: 'utf8'});
+        let minifyData = pd.xmlmin(fileRaw);
+        fs.writeFileSync(file, minifyData);
+        console.log('minify'.green, path.relative(config.workDir, file).blue);
+      });
+      resolve(files);
+    });
+  });
+}
+
+module.exports = function *() {
+  console.log('minify wxml...'.green);
+  return co(minifyWXML)
+    .then(function (files) {
+      return Promise.resolve(files);
+    })
+    .catch(function (err) {
+      console.log(err);
+      return Promise.reject(err);
+    })
+};

--- a/lib/minify-wxml.js
+++ b/lib/minify-wxml.js
@@ -6,26 +6,29 @@ const fs = require('fs');
 
 const pd = require('pretty-data').pd;
 const config = require('./config')();
-const glob = require('glob');
+const globby = require('globby');
 const co = require('co');
-const utils = require('./utils');
 
 function *minifyWXML() {
-  const srcFiles = path.join(config.distDir, 'pages/', '**', '**', '*.wxml');
+  const pageFiles = path.join(config.distDir, 'pages/', '**', '**', '*.wxml');
+  const tplFiles = path.join(config.distDir, 'templates/', '**', '**', '*.wxml');
+  const distAllFiles = path.join(config.distDir, '**', '**', '*.wxml');
+
+  let files = yield globby([
+    pageFiles,
+    tplFiles,
+    distAllFiles
+  ]);
 
   return new Promise(function (resolve, reject) {
-    // options is optional
-    glob(srcFiles, {}, function (err, files) {
-      if (err) return reject(err);
-      if (!files || !files.length) return resolve(null);
-      files.forEach(function (file) {
-        let fileRaw = fs.readFileSync(file, {encoding: 'utf8'});
-        let minifyData = pd.xmlmin(fileRaw);
-        fs.writeFileSync(file, minifyData);
-        console.log('minify'.green, path.relative(config.workDir, file).blue);
-      });
-      resolve(files);
+    if (!files || !files.length) files = [];
+    files.forEach(function (file) {
+      let fileRaw = fs.readFileSync(file, {encoding: 'utf8'});
+      let minifyData = pd.xmlmin(fileRaw);
+      fs.writeFileSync(file, minifyData);
+      console.log('minify'.green, path.relative(config.workDir, file).blue);
     });
+    resolve(files);
   });
 }
 

--- a/lib/minify-wxss.js
+++ b/lib/minify-wxss.js
@@ -1,0 +1,43 @@
+/**
+ * Created by axetroy on 17-2-13.
+ */
+const path = require('path');
+const fs = require('fs');
+
+const pd = require('pretty-data').pd;
+const config = require('./config')();
+const globby = require('globby');
+const co = require('co');
+
+function *minifyWXML() {
+  const pageFiles = path.join(config.distDir, 'pages/', '**', '**', '*.wxss');
+  const distAllFiles = path.join(config.distDir, '**', '**', '*.wxss');
+
+  let files = yield globby([
+    pageFiles,
+    distAllFiles
+  ]);
+
+  return new Promise(function (resolve, reject) {
+    if (!files || !files.length) files = [];
+    files.forEach(function (file) {
+      let fileRaw = fs.readFileSync(file, {encoding: 'utf8'});
+      let minifyData = pd.cssmin(fileRaw);
+      fs.writeFileSync(file, minifyData);
+      console.log('minify'.green, path.relative(config.workDir, file).blue);
+    });
+    resolve(files);
+  });
+}
+
+module.exports = function *() {
+  console.log('minify wxss...'.green);
+  return co(minifyWXML)
+    .then(function (files) {
+      return Promise.resolve(files);
+    })
+    .catch(function (err) {
+      console.log(err);
+      return Promise.reject(err);
+    })
+};

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -124,7 +124,7 @@ function* watch(options) {
     }
   }
 
-  chokidar.watch(config.srcDir, { ignored: /^\./ }).on('all', (event, source) => {
+  chokidar.watch(config.srcDir, {ignored: /^\.|___jb_tmp___$/}).on('all', (event, source) => {
     if (event === 'addDir') return;
     co(buildFile(source)).catch((error) => {
       console.log(error.codeFrame || error.stack || '');

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "commander": "^2.9.0",
     "download-github-repo": "^0.1.3",
     "es6-promisify": "^5.0.0",
+    "globby": "^6.1.0",
     "json5": "^0.5.0",
     "less": "^2.7.1",
     "minimatch": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "shelljs": "^0.7.4",
     "slash": "^1.0.0",
     "uglify-js": "^2.7.3",
+    "underscore": "^1.8.3",
     "update-notifier": "^1.0.2",
     "xmldom": "^0.1.22"
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "less": "^2.7.1",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.1",
+    "pretty-data": "^0.40.0",
     "radix64": "^1.1.0",
     "shelljs": "^0.7.4",
     "slash": "^1.0.0",


### PR DESCRIPTION
在开发过程中，使用 `labrador watch` 构建出来的未压缩过的包往往很大。

甚至超过1M，导致在微信调试工具中，无法上传到服务器生成二维码。

所以，干脆就在build上加上watch

====== 2017.02.13 ======
labrador build 增加wxml/wxss/json格式的压缩，1M的限制，多用一分就是奢侈...

增加三个参数
```javascript
program
  .option('--ignore-minify-wxml', '忽略压缩WXML代码')
  .option('--ignore-minify-wxss', '忽略压缩WXSS代码')
  .option('--ignore-minify-json', '忽略压缩JSON文件')
```

> 用习惯了``yarn add xxx``，然后用到``npm install xxx``老是忘记加--save (逃